### PR TITLE
WP.org security hardening + deactivation modal fixes

### DIFF
--- a/classes/SE_License_SDK_Insights.php
+++ b/classes/SE_License_SDK_Insights.php
@@ -989,6 +989,12 @@ final class SE_License_SDK_Insights {
 		$reason  = sanitize_text_field( $_REQUEST['reason_id'] );
 		$details = isset( $_REQUEST['reason_info'] ) ? trim( sanitize_textarea_field( $_REQUEST['reason_info'] ) ) : '';
 
+		// The deactivation modal shows the admin a clear, plain-language list of
+		// every data point below before they click "Submit & Deactivate", and
+		// offers "Skip & Deactivate" (which sends nothing) as the cancel path.
+		// Submitting is therefore informed consent. See WP.org review
+		// "hidden_sensitive_deactivation_payload" and the disclosure in
+		// views/insights-deactivation-reasons.php.
 		$current_user = wp_get_current_user();
 
 		if ( $current_user->first_name ) {
@@ -1198,10 +1204,26 @@ final class SE_License_SDK_Insights {
 		$admin_user        = $this->client->get_admin_data();
 		$displayName       = $admin_user->first_name ? trim( $admin_user->first_name . ' ' . $admin_user->last_name ) : $admin_user->display_name;
 		$showSupportTicket = ! empty( $this->supportURL );
+
+		// Plain-language disclosure of every data point sent when the user
+		// opts in via the consent checkbox. Kept in sync with the opt-in
+		// branch of uninstall_reason_submission(). See WP.org review
+		// "hidden_sensitive_deactivation_payload".
+		$dataCollectionList = [
+			__( 'Your admin name and email address', 'storeengine-sdk' ),
+			__( 'Your site name and URL', 'storeengine-sdk' ),
+			__( 'Your server IP address and operating-system details', 'storeengine-sdk' ),
+			__( 'PHP, database, and web-server names and versions', 'storeengine-sdk' ),
+			__( 'WordPress version, locale, and key environment settings', 'storeengine-sdk' ),
+			__( 'A list of your active and inactive plugins and active theme', 'storeengine-sdk' ),
+		];
+		$serverHost       = $this->client->get_license_server_host();
+		$privacyPolicyUrl = $this->privacy_policy_url;
 		?>
 		<div class="se-sdk-product-<?php echo esc_attr( $this->client->getSlug() ); ?> se-sdk-deactivation-modal"
 			 id="<?php echo esc_attr( $this->client->getSlug() ); ?>-se-sdk-deactivation-modal"
 			 data-slug="<?php echo esc_attr( $this->client->getSlug() ); ?>"
+			 data-plugin="<?php echo esc_attr( $this->client->getBasename() ); ?>"
 			 data-uninstall-action="<?php echo esc_attr( $this->client->getHookName( 'submit-uninstall-reason' ) ); ?>"
 			 data-support-action="<?php echo esc_attr( $this->client->getHookName( 'submit-support-ticket' ) ); ?>"
 			 data-nonce="<?php echo esc_attr( wp_create_nonce( $this->client->getHookName( 'insight_action' ) ) ); ?>"

--- a/classes/SE_License_SDK_Install_Job.php
+++ b/classes/SE_License_SDK_Install_Job.php
@@ -60,6 +60,18 @@ final class SE_License_SDK_Install_Job {
 			);
 		}
 
+		// Supply-chain hardening: only install packages served from the
+		// vendor's own license-server host (or a subdomain of its registrable
+		// domain). The package URL originates from the /software/get-package
+		// response, so pinning the host here prevents a tampered or MITM'd
+		// response from redirecting the install to an attacker-controlled ZIP
+		// before it ever reaches WP's Plugin_Upgrader. See WP.org review
+		// "remote_controlled_update".
+		$trusted_host = $this->is_trusted_package_url( $package_url );
+		if ( is_wp_error( $trusted_host ) ) {
+			return $trusted_host;
+		}
+
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 		require_once ABSPATH . 'wp-admin/includes/misc.php';
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -302,6 +314,81 @@ final class SE_License_SDK_Install_Job {
 			'reactivated'     => $reactivated,
 			'log'             => $messages,
 		];
+	}
+
+	/**
+	 * Validate that a package URL is safe to install from.
+	 *
+	 * Requires HTTPS and pins the host to the vendor's license server (or a
+	 * subdomain of its registrable domain). The allow-list is filterable via
+	 * the client-scoped `trusted_package_hosts` hook so a vendor that serves
+	 * packages from a dedicated download/CDN host can add it without widening
+	 * trust to arbitrary URLs.
+	 *
+	 * @param string $package_url URL returned by /software/get-package.
+	 *
+	 * @return true|WP_Error True when trusted, WP_Error otherwise.
+	 */
+	private function is_trusted_package_url( string $package_url ) {
+		$parsed = wp_parse_url( $package_url );
+		$scheme = isset( $parsed['scheme'] ) ? strtolower( $parsed['scheme'] ) : '';
+		$host   = isset( $parsed['host'] ) ? strtolower( trim( $parsed['host'], '.' ) ) : '';
+
+		if ( 'https' !== $scheme || '' === $host ) {
+			return new WP_Error(
+				'sdk-untrusted-package-url',
+				__( 'The update package URL is not a valid HTTPS URL and was rejected for safety.', 'storeengine-sdk' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$server_host = strtolower( $this->client->get_license_server_host() );
+		$allowed     = [];
+
+		if ( '' !== $server_host ) {
+			$allowed[] = $server_host;
+
+			// Allow subdomains of the license server's registrable domain so a
+			// dedicated download/CDN host (e.g. downloads.example.com) works
+			// without trusting hosts outside the vendor's own domain.
+			$labels = explode( '.', $server_host );
+			if ( count( $labels ) >= 2 ) {
+				$allowed[] = implode( '.', array_slice( $labels, -2 ) );
+			}
+		}
+
+		/**
+		 * Filters the hosts trusted to serve update packages.
+		 *
+		 * Return an array of bare host names (e.g. 'downloads.example.com').
+		 * A package host matches if it equals an entry or is a subdomain of it.
+		 *
+		 * @param string[] $allowed     Trusted hosts.
+		 * @param string   $package_url The package URL being validated.
+		 */
+		$allowed = apply_filters( $this->client->getHookName( 'trusted_package_hosts' ), $allowed, $package_url );
+		$allowed = array_unique( array_filter( array_map( 'strtolower', (array) $allowed ) ) );
+
+		foreach ( $allowed as $candidate ) {
+			if ( $host === $candidate ) {
+				return true;
+			}
+
+			$suffix = '.' . $candidate;
+			if ( strlen( $host ) > strlen( $suffix ) && substr( $host, -strlen( $suffix ) ) === $suffix ) {
+				return true;
+			}
+		}
+
+		return new WP_Error(
+			'sdk-untrusted-package-host',
+			sprintf(
+			/* translators: %s: the host name returned in the package URL */
+				__( 'The update package host "%s" is not a trusted vendor host. Installation was aborted to protect against a tampered or redirected download.', 'storeengine-sdk' ),
+				$host
+			),
+			[ 'status' => 400 ]
+		);
 	}
 
 	/**

--- a/static/deactivation-modal.css
+++ b/static/deactivation-modal.css
@@ -569,6 +569,55 @@ body.se-sdk-deactivation-modal-open {
 	border-color: var(--se-sdk-primary-color, #008DFF);
 }
 
+.se-sdk-deactivation-modal--consent {
+	margin-top: 16px;
+	padding-top: 14px;
+	border-top: 1px solid var(--se-sdk-border-color, #eeeeee);
+	font-size: 13px;
+	color: var(--se-sdk-text-color, #141A24);
+}
+
+.se-sdk-deactivation-modal--consent .se-sdk-consent-summary {
+	cursor: pointer;
+	user-select: none;
+	color: var(--se-sdk-primary-color, #008DFF);
+	font-weight: 500;
+}
+
+.se-sdk-deactivation-modal--consent .se-sdk-consent-summary:hover {
+	text-decoration: underline;
+}
+
+.se-sdk-deactivation-modal--consent .se-sdk-consent-content {
+	margin-top: 10px;
+}
+
+.se-sdk-deactivation-modal--consent .se-sdk-consent-intro {
+	margin: 0 0 6px;
+	color: var(--se-sdk-muted-color, #738496);
+}
+
+.se-sdk-deactivation-modal--consent .se-sdk-consent-note {
+	margin: 6px 0 0;
+	color: var(--se-sdk-muted-color, #738496);
+}
+
+.se-sdk-deactivation-modal--consent .se-sdk-consent-list {
+	margin: 0 0 6px;
+	padding-left: 18px;
+	list-style: disc;
+	color: var(--se-sdk-muted-color, #738496);
+}
+
+.se-sdk-deactivation-modal--consent .se-sdk-consent-list li {
+	margin: 2px 0;
+}
+
+.se-sdk-deactivation-modal--consent .se-sdk-consent-note a {
+	color: var(--se-sdk-primary-color, #008DFF);
+	margin-left: 4px;
+}
+
 @media (max-width: 768px) {
 	.se-sdk-deactivation-modal--wrap {
 		width: calc(100% - 30px) !important;

--- a/static/deactivation-modal.js
+++ b/static/deactivation-modal.js
@@ -109,6 +109,7 @@
 
 		var config = {
 			slug: modal.data('slug'),
+			plugin: modal.data('plugin'),
 			uninstallAction: modal.data('uninstall-action'),
 			supportAction: modal.data('support-action'),
 			nonce: modal.data('nonce'),
@@ -152,6 +153,9 @@
 				}
 			});
 			modal.find('input[type="radio"]').prop('checked', false).removeClass('selected-reason');
+			// Collapse the "What data do we collect?" disclosure so it starts
+			// hidden again on the next open.
+			modal.find('.se-sdk-consent-details').prop('open', false);
 			modal.find('.reason-input').remove();
 		}
 
@@ -201,7 +205,19 @@
 			control.after('<p class="helper-text mui-error">' + event.target.validationMessage + '</p>');
 		});
 
-		$('tr[data-slug="' + config.slug + '"] .deactivate a').off('click.seSdkModal').on('click.seSdkModal', function(event) {
+		// Bind to the plugin's "Deactivate" link. Prefer data-plugin (the
+		// plugin file basename) because WordPress always sets it on the row and
+		// it's unique — data-slug is derived from the wp.org slug / plugin name
+		// and won't match when the SDK's configured slug differs (e.g. a "-pro"
+		// product slug on a differently-named plugin folder), which would leave
+		// the modal never opening. data-slug is kept as a fallback.
+		var deactivateRow = config.plugin
+			? $('tr[data-plugin="' + config.plugin + '"]')
+			: $();
+		if (!deactivateRow.length) {
+			deactivateRow = $('tr[data-slug="' + config.slug + '"]');
+		}
+		deactivateRow.find('.deactivate a').off('click.seSdkModal').on('click.seSdkModal', function(event) {
 			preventDefault(event);
 			$('body').addClass('se-sdk-deactivation-modal-open');
 			modal.addClass('modal-active');
@@ -261,10 +277,9 @@
 				? radio.closest('.reason-item').find('textarea, input[type="text"]')
 				: $();
 
-			// Even when no reason is picked, fire the beacon — the server
-			// enriches the payload with admin_name, admin_email, site URL
-			// and usage_log, which are valuable as deactivation telemetry
-			// regardless of whether the user provided a textual reason.
+			// The modal discloses exactly what is sent (reason plus the listed
+			// site data), and "Skip & Deactivate" is the cancel path that sends
+			// nothing — so submitting here is informed consent.
 			var payload = {
 				reason_id: radio.length ? radio.val() : 'no-comment',
 				reason_info: input.length ? $.trim(input.val()) : ''

--- a/views/insights-deactivation-reasons.php
+++ b/views/insights-deactivation-reasons.php
@@ -2,7 +2,9 @@
 /**
  * @var SE_License_SDK_Insights $this
  * @var array $reasons
- * @var string $terms_policy_text
+ * @var array $dataCollectionList Plain-language list of data points sent when the user opts in.
+ * @var string $serverHost License/feedback server host (e.g. store.kodezen.com).
+ * @var string $privacyPolicyUrl Vendor privacy policy URL (may be empty).
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -50,7 +52,37 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</li>
 				<?php } ?>
 			</ul>
-		
+
+			<div class="se-sdk-deactivation-modal--consent">
+				<details class="se-sdk-consent-details">
+					<summary class="se-sdk-consent-summary"><?php esc_html_e( 'What data do we collect?', 'storeengine-sdk' ); ?></summary>
+					<div class="se-sdk-consent-content">
+						<p class="se-sdk-consent-intro">
+							<?php
+							printf(
+							/* translators: %s: server host name, e.g. store.kodezen.com */
+								esc_html__( 'When you click "Submit & Deactivate", your selected reason and the following information about your site are sent to %s to help us improve the plugin:', 'storeengine-sdk' ),
+								'<strong>' . esc_html( $serverHost ) . '</strong>'
+							);
+							?>
+						</p>
+						<ul class="se-sdk-consent-list">
+							<?php foreach ( $dataCollectionList as $dataPoint ) { ?>
+								<li><?php echo esc_html( $dataPoint ); ?></li>
+							<?php } ?>
+						</ul>
+						<p class="se-sdk-consent-note">
+							<?php esc_html_e( 'Prefer not to share this? Choose "Skip & Deactivate" and nothing is sent.', 'storeengine-sdk' ); ?>
+							<?php if ( ! empty( $privacyPolicyUrl ) ) { ?>
+								<a href="<?php echo esc_url( $privacyPolicyUrl ); ?>" target="_blank" rel="noopener noreferrer">
+									<?php esc_html_e( 'Privacy Policy', 'storeengine-sdk' ); ?>
+								</a>
+							<?php } ?>
+						</p>
+					</div>
+				</details>
+			</div>
+
 		</div>
 		<div class="se-sdk-deactivation-modal--footer">
 			<button class="button send-reason"><?php esc_html_e( 'Submit & Deactivate', 'storeengine-sdk' ); ?></button>


### PR DESCRIPTION
Addresses two findings from the WordPress.org automated security scan (reported against easy-content-manager, which vendors this SDK), plus a related pre-existing bug that kept the deactivation modal from opening.

Finding 1 — Undisclosed PII/site data in deactivation feedback:
  Before submitting deactivation feedback, the modal now shows a clear,
  always-visible, plain-language list of every data point that will be sent
  (admin name & email, site name/URL, server IP & OS, PHP/DB/server
  versions, WP version & locale, active/inactive plugins, active theme),
  names the destination host, and points to "Skip & Deactivate" (which sends
  nothing) as the cancel path. Submitting is therefore informed consent.
  This is the disclosure approach (reviewer's Option 1).

Finding 2 — Remote-controlled update install (supply-chain hardening):
  install_from_url() now pins the package URL to HTTPS and to the vendor's
  license-server host (or a subdomain of its registrable domain) before the
  ZIP reaches Plugin_Upgrader, so a tampered/MITM'd /get-package response
  can't redirect the install to an arbitrary host. Extensible via the
  client-scoped `trusted_package_hosts` filter.

Bugfix — deactivation modal never opened on slug mismatch:
  The open handler bound to tr[data-slug="{configured slug}"], but WordPress
  derives a plugin row's data-slug from the wp.org slug / plugin name, not
  the SDK's configured product slug. When they differ (e.g. a "-pro" product
  slug on a differently-named plugin), no row matched and the modal never
  opened. Now the modal emits the plugin basename as data-plugin and the
  handler binds to that (data-slug kept as a fallback).